### PR TITLE
Fix bug where comma appears when there is not a second proprietor. 

### DIFF
--- a/application/frontend/templates/view_property.html
+++ b/application/frontend/templates/view_property.html
@@ -62,11 +62,11 @@
                     <dd>
                         {% for proprietor in title.proprietors %}
                             {% if  proprietor.first_name and proprietor.last_name %}
+                                {% if not loop.first %}, {% endif %}
                                 {{ proprietor.first_name }} {{ proprietor.last_name }}
                                 <span class='change edit-mode'>
                                     (<a href='{{request.path}}/edit/title.proprietor.{{loop.index}}'>change</a>)
                                 </span>
-                                {% if not loop.last %}, {% endif %}
                             {% endif %}
                         {% endfor %}
                     </dd>


### PR DESCRIPTION
The real fix for this is to update the RegistrationForm.to_dict() in casework-frontend to only add the 2nd proprietor if there is one.
https://www.pivotaltracker.com/story/show/76293734
