### PR TITLE
removing cookie warning text

### DIFF
--- a/application/frontend/templates/global/landregistry_base.html
+++ b/application/frontend/templates/global/landregistry_base.html
@@ -6,12 +6,6 @@
   {% block head_additionals %}{% endblock %}
 {% endblock %}
 
-
-{% block cookie_message %}
-  <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
-{% endblock %}
-
-
 {% block body_end %}
   <script src="{{ landregistry_asset_path }}javascripts/land-registry-scripts.js"></script>
   <script src="{{ asset_path }}javascripts/vendor/leaflet-0.7.3/leaflet.js"></script>


### PR DESCRIPTION
See line 30 of https://docs.google.com/a/digital.landregistry.gov.uk/spreadsheets/d/18HH0N0-NRx_zn82sIk2tIGaggcrl9W7-8iLDGNGqEhE/edit#gid=0
