### PR TITLE
Move auth routes to blueprint and out of server

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -18,8 +18,6 @@ app.config.from_object(os.environ.get('SETTINGS'))
 
 login_manager = LoginManager()
 login_manager.init_app(app)
-login_manager.login_view = 'login'
-login_manager.login_message = ''
 
 db = SQLAlchemy(app)
 SQLAlchemy.health = health
@@ -54,6 +52,12 @@ if 'SENTRY_DSN' in os.environ:
     sentry = Sentry(app, dsn=os.environ['SENTRY_DSN'])
 
 app.logger.info("\nConfiguration\n%s\n" % app.config)
+
+# import and register auth blueprint
+from .auth.views import auth
+app.register_blueprint(auth)
+login_manager.login_view = 'auth.login'
+login_manager.login_message = ''
 
 
 def health(self):

--- a/application/auth/forms.py
+++ b/application/auth/forms.py
@@ -1,0 +1,26 @@
+from flask import request
+
+from flask_wtf import Form
+
+from wtforms import (
+    StringField,
+    HiddenField,
+    PasswordField,
+    SubmitField
+)
+
+from wtforms.validators import (
+    DataRequired,
+    Email
+)
+
+class LoginForm(Form):
+    email = StringField('User name', validators=[DataRequired(), Email()])
+    password = PasswordField(validators=[DataRequired()])
+    submit = SubmitField('Sign in')
+    next = HiddenField()
+
+    def __init__(self, *args, **kwargs):
+        super(LoginForm, self).__init__(*args, **kwargs)
+        if not self.next.data:
+            self.next.data = request.args.get('next', '')

--- a/application/auth/views.py
+++ b/application/auth/views.py
@@ -1,0 +1,44 @@
+from flask import (
+    Blueprint,
+    render_template,
+    flash,
+    session,
+    redirect,
+    url_for
+)
+
+from flask.ext.login import (
+    login_user,
+    logout_user,
+    login_required,
+    current_app
+)
+
+from application.services import is_allowed_to_see_title
+
+from .models import User
+from .forms import LoginForm
+
+auth = Blueprint('auth', __name__, template_folder='templates' , url_prefix='/auth')
+
+@auth.route('/login', methods=['GET', 'POST'])
+def login():
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = User.query.get(form.email.data)
+        if user and is_allowed_to_see_title(user, form.password.data):
+            login_user(user)
+            return redirect(form.next.data or url_for('index'))
+        else:
+            current_app.logger.info("Login failed for user email %s" % form.email.data)
+            flash("Sorry, those details haven&rsquo;t been recognised. Please try again.")
+    return render_template("auth/login_user.html", form=form)
+
+
+@auth.route("/logout")
+@login_required
+def logout():
+    session.pop("lrid", None)
+    session.pop("roles", None)
+    logout_user()
+    return redirect(url_for('auth.login'))

--- a/application/frontend/forms.py
+++ b/application/frontend/forms.py
@@ -7,7 +7,6 @@ from wtforms import (
     HiddenField,
     BooleanField,
     DateField,
-    PasswordField,
     SubmitField,
     SelectField,
     RadioField,
@@ -31,19 +30,6 @@ class ValidateDateNotInFuture(object):
     def _validate_date_not_in_future(self, form, date_field):
         if date_field > date.today():
             raise ValidationError('Date cannot be in the future')
-
-
-class LoginForm(Form):
-    email = StringField(validators=[DataRequired()])
-    password = PasswordField(validators=[DataRequired()])
-    submit = SubmitField('Sign in')
-    next = HiddenField()
-
-    def __init__(self, *args, **kwargs):
-        super(LoginForm, self).__init__(*args, **kwargs)
-        if not self.next.data:
-            self.next.data = request.args.get('next', '')
-
 
 class ChangeForm(Form):
     title_number = HiddenField('Title Number')

--- a/application/frontend/server.py
+++ b/application/frontend/server.py
@@ -10,18 +10,15 @@ from flask import (
     url_for,
     flash,
     session,
-    current_app)
-
+    current_app
+)
 from flask.ext.login import (
-    login_user,
-    logout_user,
     login_required,
     current_user
 )
 from forms import (
     ChangeForm,
     ConfirmForm,
-    LoginForm,
     SelectTaskForm,
     ConveyancerAddClientForm
 )
@@ -106,7 +103,7 @@ def property_by_title(title_number):
            address=address,
            apiKey=app.config['OS_API_KEY'])
     else:
-        return redirect(url_for('.login'))
+        return redirect(url_for('auth.login'))
 
 
 # Sticking to convention, "/property/<title_number>" will show the
@@ -152,27 +149,27 @@ def _get_title(title_number):
     return response.json()
 
 
-@app.route('/login', methods=['GET', 'POST'])
-def login():
-    form = LoginForm()
-    if form.validate_on_submit():
-        user = User.query.get(form.email.data)
-        if user and is_allowed_to_see_title(user, form.password.data):
-            login_user(user)
-            return redirect(form.next.data or url_for('.index'))
-        else:
-            app.logger.info("Login failed for user email %s" % form.email.data)
-            flash("Sorry, those details haven&rsquo;t been recognised. Please try again.")
-    return render_template("auth/login_user.html", form=form)
+# @app.route('/login', methods=['GET', 'POST'])
+# def login():
+#     form = LoginForm()
+#     if form.validate_on_submit():
+#         user = User.query.get(form.email.data)
+#         if user and is_allowed_to_see_title(user, form.password.data):
+#             login_user(user)
+#             return redirect(form.next.data or url_for('.index'))
+#         else:
+#             app.logger.info("Login failed for user email %s" % form.email.data)
+#             flash("Sorry, those details haven&rsquo;t been recognised. Please try again.")
+#     return render_template("auth/login_user.html", form=form)
 
 
-@app.route("/logout")
-@login_required
-def logout():
-    session.pop("lrid", None)
-    session.pop("roles", None)
-    logout_user()
-    return redirect(url_for('.login'))
+# @app.route("/logout")
+# @login_required
+# def logout():
+#     session.pop("lrid", None)
+#     session.pop("roles", None)
+#     logout_user()
+#     return redirect(url_for('.login'))
 
 
 @app.route('/relationship/client')

--- a/application/frontend/templates/auth/login_user.html
+++ b/application/frontend/templates/auth/login_user.html
@@ -15,7 +15,7 @@
 
         <div class="full-width">
 
-          <form action="/login" method="POST" name="form" class="login-user-form">
+          <form action="{{ url_for('auth.login') }}" method="POST" name="form" class="login-user-form">
 
             <h1 class="form-title heading-large">Sign in</h1>
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -40,19 +40,19 @@ class AuditTestCase(unittest.TestCase):
         self.lrid = uuid.uuid4()
         self.roles = ['CITIZEN']
 
-    def _login(self, email=None, password=None):
+    def login(self, email=None, password=None):
         password = password or 'password'
-        return self.client.post('/login', data={'email': email, 'password': password}, follow_redirects=True)
+        return self.client.post('/auth/login', data={'email': email, 'password': password}, follow_redirects=True)
 
     def logout(self):
-        return self.client.get('/logout', follow_redirects=True)
+        return self.client.get('/auth/logout', follow_redirects=True)
 
 
     @mock.patch(LOGGER)
     @mock.patch('requests.post')
     def test_audit_get_index_logs_authenticated_user(self, mock_post, mock_logger):
         mock_post.return_value.json.return_value = {"lrid":self.lrid, "roles":self.roles}
-        self._login('landowner@mail.com', 'password')
+        self.login('landowner@mail.com', 'password')
         path = '/'
         self.client.get(path)
         args, kwargs = mock_logger.call_args
@@ -66,7 +66,7 @@ class AuditTestCase(unittest.TestCase):
     def test_audit_get_property_page_logs_authenticated_user(self, mock_owner_check, mock_get,mock_post, mock_logger):
         mock_post.return_value.json.return_value = {"lrid":self.lrid, "roles":self.roles}
         mock_get.return_value.json.return_value = title
-        self._login('landowner@mail.com', 'password')
+        self.login('landowner@mail.com', 'password')
         path = '/property/TEST123'
         self.client.get(path)
         args, kwargs = mock_logger.call_args

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -49,10 +49,10 @@ class AuthenticationTestCase(unittest.TestCase):
 
     def login(self, email=None, password=None):
         password = password or 'password'
-        return self.client.post('/login', data={'email': email, 'password': password}, follow_redirects=True)
+        return self.client.post('/auth/login', data={'email': email, 'password': password}, follow_redirects=True)
 
     def logout(self):
-        return self.client.get('/logout', follow_redirects=True)
+        return self.client.get('/auth/logout', follow_redirects=True)
 
     @mock.patch('requests.post')
     def test_login(self, mock_post):

--- a/tests/test_view_titles.py
+++ b/tests/test_view_titles.py
@@ -153,7 +153,7 @@ class ViewFullTitleTestCase(unittest.TestCase):
         with self.client:
             from flask.ext.login import current_user
 
-            self.client.post('/login', data={'email': user.email, 'password': 'password'}, follow_redirects=True)
+            self.client.post('/auth/login', data={'email': user.email, 'password': 'password'}, follow_redirects=True)
             responses.add(responses.GET, '%s/auth/titles/%s' % (self.search_api, TITLE_NUMBER),
               body = response_json, status = 200, content_type='application/json')
 
@@ -191,7 +191,7 @@ class ViewFullTitleTestCase(unittest.TestCase):
 
             app.config['VIEW_COUNT'] = 1
 
-            self.client.post('/login', data={'email': user.email, 'password': 'password'}, follow_redirects=True)
+            self.client.post('/auth/login', data={'email': user.email, 'password': 'password'}, follow_redirects=True)
             responses.add(responses.GET, '%s/auth/titles/%s' % (self.search_api, TITLE_NUMBER),
               body = response_json, status = 200, content_type='application/json')
 
@@ -199,7 +199,7 @@ class ViewFullTitleTestCase(unittest.TestCase):
             response = self.client.get('/property/%s' % TITLE_NUMBER)
 
             self.assertEquals(302, response.status_code)
-            self.assertEquals(response.headers['location'], 'http://localhost/login')
+            self.assertEquals(response.headers['location'], 'http://localhost/auth/login')
             self.assertTrue(mock_logout.called)
 
 


### PR DESCRIPTION
Removed commented out code. Fix login.view config

@servingUpAces can you have a quick look. I'm planning to do the same for conveyancer before tackling a cleanup so that all the routes for that will be in another blueprint. that should help in understanding what is going on, or at least reduce noise.
